### PR TITLE
fix!: typo in removeLayerOverride

### DIFF
--- a/src/Statsig.ts
+++ b/src/Statsig.ts
@@ -346,7 +346,7 @@ export default class Statsig {
   /**
    * @param name the config override to remove
    */
-  public static removeLayerOverrie(name?: string): void {
+  public static removeLayerOverride(name?: string): void {
     if (!this.isInitialized()) {
       return;
     }


### PR DESCRIPTION
BREAKING CHANGE: public method removeLayerOverrie renamed to renameLayerOverride