### PR TITLE
v1.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.22.0",
       "license": "ISC",
       "dependencies": {
-        "statsig-js": "^4.28.1"
+        "statsig-js": "^4.30.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.14.1",
@@ -3502,13 +3502,10 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3702,12 +3699,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -4251,13 +4242,12 @@
       }
     },
     "node_modules/statsig-js": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/statsig-js/-/statsig-js-4.28.1.tgz",
-      "integrity": "sha512-ZRmkWWsst06JWT9jQncLDLG1KGXnLtaHvMoeC6pLUa4n6sU0It0SpupVTeC+60wH3I/+PHU2y6C5u7bR1MFzMA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/statsig-js/-/statsig-js-4.30.0.tgz",
+      "integrity": "sha512-UcoqJZGUMQDvpAAOXW/ZXyKgXvV8M5xistHmfX7dHsS5rvJSUz9foRq4lQ8EsZUDT6yV9cbn9zY+werAW8obcw==",
       "dependencies": {
         "js-sha256": "^0.9.0",
-        "uuid": "^8.3.2",
-        "whatwg-fetch": "^3.6.2"
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/string-length": {
@@ -4646,11 +4636,6 @@
       "dependencies": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
@@ -7500,13 +7485,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
     },
     "kleur": {
       "version": "3.0.3",
@@ -7649,12 +7631,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -8077,13 +8053,12 @@
       }
     },
     "statsig-js": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/statsig-js/-/statsig-js-4.28.1.tgz",
-      "integrity": "sha512-ZRmkWWsst06JWT9jQncLDLG1KGXnLtaHvMoeC6pLUa4n6sU0It0SpupVTeC+60wH3I/+PHU2y6C5u7bR1MFzMA==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/statsig-js/-/statsig-js-4.30.0.tgz",
+      "integrity": "sha512-UcoqJZGUMQDvpAAOXW/ZXyKgXvV8M5xistHmfX7dHsS5rvJSUz9foRq4lQ8EsZUDT6yV9cbn9zY+werAW8obcw==",
       "requires": {
         "js-sha256": "^0.9.0",
-        "uuid": "^8.3.2",
-        "whatwg-fetch": "^3.6.2"
+        "uuid": "^8.3.2"
       }
     },
     "string-length": {
@@ -8364,11 +8339,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statsig-react",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "statsig-react",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "ISC",
       "dependencies": {
         "statsig-js": "^4.30.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsig-react",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "An SDK for using Statsig Feature Management and Experimentation platform in React clients",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "statsig-js": "^4.28.1"
+    "statsig-js": "^4.30.0"
   },
   "peerDependencies": {
     "react": "^16.6.3 || ^17.0.0 || ^18.0.0"

--- a/src/__tests__/StatsigSynchronousProvider.test.tsx
+++ b/src/__tests__/StatsigSynchronousProvider.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { useState } from 'react';
+import StatsigJS, { StatsigUser } from 'statsig-js';
+import StatsigSynchronousProvider from '../StatsigSynchronousProvider';
+import useUpdateUser from '../useUpdateUser';
+import * as TestData from './initialize_response.json';
+
+const TID_USER_VALUE = 'statsig-user-object';
+const TID_SET_USER_STATE = 'update-via-set-state';
+const TID_UPDATE_USER_HOOK = 'update-via-hook';
+const TID_PARTIAL_UPDATE_USER_HOOK = 'partial-update-via-hook';
+
+StatsigJS.encodeIntializeCall = false;
+let initTime = 0;
+
+function UpdateUserHookTestComponent(props: { userID: string }) {
+  const updateUser = useUpdateUser();
+
+  return (
+    <>
+      <button
+        onClick={() =>
+          updateUser((old) => {
+            return {
+              ...old,
+              userID: props.userID + '-partial-update-via-useUpdateUser',
+            };
+          })
+        }
+        data-testid={TID_PARTIAL_UPDATE_USER_HOOK}
+      />
+      <button
+        onClick={() =>
+          updateUser({
+            userID: props.userID + '-full-update-via-useUpdateUser',
+          })
+        }
+        data-testid={TID_UPDATE_USER_HOOK}
+      />
+    </>
+  );
+}
+
+function UserTestComponent(props: {
+  userID: string;
+  excludeSetUserFunc?: boolean;
+}) {
+  const [user, setUser] = useState<StatsigUser>({ userID: props.userID });
+
+  return (
+    <StatsigSynchronousProvider
+      sdkKey="client-sdk-key'"
+      user={user}
+      setUser={props.excludeSetUserFunc === true ? undefined : setUser}
+      options={{
+        disableDiagnosticsLogging: true,
+        initCompletionCallback: (duration, success, message) => {
+          initTime = duration
+        }
+      }}
+      initializeValues={TestData}
+    >
+      <div data-testid={TID_USER_VALUE}>{user.userID}</div>
+
+      <button
+        onClick={() =>
+          setUser({ userID: props.userID + '-update-via-useState' })
+        }
+        data-testid={TID_SET_USER_STATE}
+      />
+
+      <UpdateUserHookTestComponent userID={props.userID} />
+    </StatsigSynchronousProvider>
+  );
+}
+
+describe('StatsigProvider', () => {
+  let requestsMade: {
+    url: RequestInfo | URL;
+    body: Record<string, unknown>;
+  }[] = [];
+
+  async function VerifyInitializeForUserWithRender(userID: string) {
+    await waitFor(() => screen.getByText(userID));
+
+    expect(requestsMade).toEqual([
+      {
+        url: 'https://featuregates.org/v1/initialize',
+        body: expect.objectContaining({ user: { userID: userID } }),
+      },
+    ]);
+  }
+
+  // @ts-ignore
+  global.fetch = jest.fn((url, params) => {
+    const body = String(params?.body ?? '{}');
+    requestsMade.push({ url, body: JSON.parse(body) });
+  });
+
+  beforeEach(() => {
+    requestsMade = [];
+    initTime = 0;
+  });
+
+  it('renders children', async () => {
+    expect.assertions(4);
+    render(<UserTestComponent userID="a-user" />);
+
+    const child = await waitFor(() => screen.getByTestId(TID_USER_VALUE));
+    expect(child).toHaveTextContent('a-user');
+
+    expect(initTime).toBeGreaterThan(0);
+    expect(initTime).toBeLessThan(100);
+
+    expect(requestsMade).toEqual([]);
+  });
+
+  it('calls updateUser when user object changes', async () => {
+    render(<UserTestComponent userID="a-user" />);
+    await waitFor(
+      () => screen.getByTestId(TID_USER_VALUE) && requestsMade.length === 1,
+    );
+
+    requestsMade = [];
+
+    await userEvent.click(screen.getByTestId(TID_SET_USER_STATE));
+
+    await VerifyInitializeForUserWithRender('a-user-update-via-useState');
+  });
+
+  it('updates the user via the useUpdateUser hook', async () => {
+    render(<UserTestComponent userID="a-user" />);
+    await waitFor(
+      () => screen.getByTestId(TID_USER_VALUE) && requestsMade.length === 1,
+    );
+
+    expect(requestsMade).toEqual([]);
+
+    await userEvent.click(screen.getByTestId(TID_UPDATE_USER_HOOK));
+
+    await VerifyInitializeForUserWithRender(
+      'a-user-full-update-via-useUpdateUser',
+    );
+  });
+
+  it('partially updates the user via the useUpdateUser hook', async () => {
+    render(<UserTestComponent userID="a-user" />);
+    await waitFor(
+      () => screen.getByTestId(TID_USER_VALUE) && requestsMade.length === 1,
+    );
+
+    expect(requestsMade).toEqual([]);
+
+    await userEvent.click(screen.getByTestId(TID_PARTIAL_UPDATE_USER_HOOK));
+
+    await VerifyInitializeForUserWithRender(
+      'a-user-partial-update-via-useUpdateUser',
+    );
+  });
+});

--- a/src/__tests__/initialize_response.json
+++ b/src/__tests__/initialize_response.json
@@ -1,0 +1,88 @@
+{
+  "feature_gates": {
+    "rGc+6rvo48V4j1sXkvsGHeSfJfY7kMp1OHfQnw+3XbI=": {
+      "name": "rGc+6rvo48V4j1sXkvsGHeSfJfY7kMp1OHfQnw+3XbI=",
+      "value": true,
+      "rule_id": "6N6Z8ODekNYZ7F8gFdoLP5",
+      "secondary_exposures": []
+    },
+    "srhBjpz3NFHATrntxEsdHManNXJQZawtJUkQ3s0XT3Q=": {
+      "name": "srhBjpz3NFHATrntxEsdHManNXJQZawtJUkQ3s0XT3Q=",
+      "value": true,
+      "rule_id": "7w9rbTSffLT89pxqpyhuqK",
+      "secondary_exposures": []
+    }
+  },
+  "dynamic_configs": {
+    "RMv0YJlLOBe7cY7HgZ3Jox34R0Wrk7jLv3DZyBETA7I=": {
+      "name": "RMv0YJlLOBe7cY7HgZ3Jox34R0Wrk7jLv3DZyBETA7I=",
+      "value": { "number": 7, "string": "statsig", "boolean": false },
+      "group": "1kNmlB23wylPFZi1M0Divl",
+      "rule_id": "1kNmlB23wylPFZi1M0Divl",
+      "is_device_based": false,
+      "is_experiment_active": false,
+      "is_user_in_experiment": false,
+      "secondary_exposures": []
+    },
+    "86mj1zUC35KaWoOqpe8SKEHQjRlXOzdLfiTJU/iU+vc=": {
+      "name": "86mj1zUC35KaWoOqpe8SKEHQjRlXOzdLfiTJU/iU+vc=",
+      "value": {
+        "experiment_param": "test",
+        "layer_param": true,
+        "second_layer_param": true
+      },
+      "group": "2RamGujUou6h2bVNQWhtNZ",
+      "rule_id": "2RamGujUou6h2bVNQWhtNZ",
+      "is_device_based": false,
+      "is_experiment_active": false,
+      "is_user_in_experiment": false,
+      "secondary_exposures": []
+    }
+  },
+  "layer_configs": {
+    "f/PP7qbCqgLC28wM1ttndrM3x7KFsdceSrT7H4e7Wck=": {
+      "name": "f/PP7qbCqgLC28wM1ttndrM3x7KFsdceSrT7H4e7Wck=",
+      "value": {
+        "experiment_param": "test",
+        "layer_param": true,
+        "second_layer_param": true
+      },
+      "group": "2RamGujUou6h2bVNQWhtNZ",
+      "rule_id": "2RamGujUou6h2bVNQWhtNZ",
+      "is_device_based": false,
+      "secondary_exposures": [],
+      "allocated_experiment_name": "86mj1zUC35KaWoOqpe8SKEHQjRlXOzdLfiTJU/iU+vc=",
+      "is_experiment_active": true,
+      "is_user_in_experiment": true
+    },
+    "swfBsA2gj0FY/9mzJdHytSKjrIsN1B9nJMeTWdKN2yw=": {
+      "name": "swfBsA2gj0FY/9mzJdHytSKjrIsN1B9nJMeTWdKN2yw=",
+      "value": {
+        "b_param": "layer_default"
+      },
+      "group": "default",
+      "rule_id": "default",
+      "is_device_based": false,
+      "secondary_exposures": []
+    },
+    "gxLOmmNNwVd8rUKILhDYkZwuLBxBuwWV1xn8m0aTs/E=": {
+      "name": "gxLOmmNNwVd8rUKILhDYkZwuLBxBuwWV1xn8m0aTs/E=",
+      "value": {
+        "holdout_layer_param": "layer_default"
+      },
+      "group": "7d2E854TtGmfETdmJFip1L",
+      "rule_id": "7d2E854TtGmfETdmJFip1L",
+      "is_device_based": false,
+      "secondary_exposures": [
+        {
+          "gate": "always_on_gate",
+          "gateValue": "true",
+          "ruleID": "6N6Z8ODekNYZ7F8gFdoLP5"
+        }
+      ]
+    }
+  },
+  "sdkParams": {},
+  "has_updates": true,
+  "time": 1646026677490
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "jsx": "react",
     "esModuleInterop": true,
     "declaration": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules", "src/__tests__/*", "tsconfig.json"]


### PR DESCRIPTION
Updates from js client sdk:  https://github.com/statsig-io/js-client/releases/tag/v4.30.0

Trigger the initCompletionCallback from setInitializeValues - used when synchronously intiializing the SDK. Also prefers performance.now() when available in the browser to Date.now() for measuring the time returned in initCompletionCallback

Adds the Statsig.initializeCalled() as a convenience method so you can check if you have previously called initialize. Note that waiting for the initialize promise to resolve is still the proper way to wait for initialization

Internal updates:

send event log failure telemetry to a different endpoint for better redundancy.
update eval reason when cached values are up to date
dont rotate session id on update user